### PR TITLE
Add network start/stop functionality for tmtestnet tool

### DIFF
--- a/docs/network-layout-spec.md
+++ b/docs/network-layout-spec.md
@@ -15,6 +15,7 @@ proposed tool:
 # A global identifier to apply across the entire test network. Will be added
 # to the `Group` tags on all created AWS resources. This identifier is included
 # in metrics submitted from the Tendermint nodes in this network.
+# This is also used as the Tendermint network chain ID.
 id: testnet_abcd
 
 # Configuration relating to monitoring of the Tendermint network nodes. Right

--- a/tendermint/ansible/start-tendermint.yaml
+++ b/tendermint/ansible/start-tendermint.yaml
@@ -1,7 +1,0 @@
----
-- hosts: tendermint
-  become: yes
-  become_user: root
-  tasks:
-    - name: Ensure Tendermint service is started
-      service: name=tendermint state=started

--- a/tendermint/ansible/tendermint-state.yaml
+++ b/tendermint/ansible/tendermint-state.yaml
@@ -1,0 +1,7 @@
+---
+- hosts: tendermint
+  become: yes
+  become_user: root
+  tasks:
+    - name: Set Tendermint service to desired state
+      service: "name=tendermint state={{ state }}"


### PR DESCRIPTION
As per the [spec](https://github.com/interchainio/testnets/blob/master/docs/network-layout-spec.md), this adds the network `start` and `stop` commands/functionality to be able to interact with the whole network, or a group of nodes, or individual nodes.